### PR TITLE
New url for fedora instance

### DIFF
--- a/sigs/fedora/cluster.md
+++ b/sigs/fedora/cluster.md
@@ -1,11 +1,11 @@
 # Fedora Konflux Cluster
 
-This is a list of notes about the [Fedora Konflux cluster](https://konflux.apps.kfluxfedorap01.toli.p1.openshiftapps.com/application-pipeline/).
+This is a list of notes about the [Fedora Konflux cluster](https://konflux.fedoraproject.org/).
 
 * **Konflux** is a new build, test, and release platform. Learn more at https://konflux-ci.dev/ and https://github.com/konflux-ci/
 * **Fedora** is your Operating System, built with love by people. Learn more at https://fedoraproject.org/
 
-For [flock 2024](https://fedoraproject.org/flock/2024/), the Konflux community provisioned a [dedicated instance of Konflux for Fedora](https://konflux.apps.kfluxfedorap01.toli.p1.openshiftapps.com/application-pipeline/) for community members to try, experiment, and play with. Big kudos to [@gbenhaim](https://github.com/gbenhaim) and [@manish-jangra](https://github.com/manish-jangra) for making it happen, and [@zlopez](https://github.com/zlopez) for helping with the [FAS oidc setup](https://pagure.io/fedora-infrastructure/issue/12075).
+For [flock 2024](https://fedoraproject.org/flock/2024/), the Konflux community provisioned a [dedicated instance of Konflux for Fedora](https://konflux.fedoraproject.org/) for community members to try, experiment, and play with. Big kudos to [@gbenhaim](https://github.com/gbenhaim) and [@manish-jangra](https://github.com/manish-jangra) for making it happen, and [@zlopez](https://github.com/zlopez) for helping with the [FAS oidc setup](https://pagure.io/fedora-infrastructure/issue/12075).
 
 This instance exists to help facilitate a dialog about what the Fedora community wants to do with respect to Konflux. Try to use it to build some stuff and see how the different konflux [resources](https://konflux-ci.dev/architecture/architecture/index.html) work. We'll keep it working and if Fedora decides to use it more, we'll seek a method to support it together with the Fedora Infra team.
 
@@ -22,7 +22,7 @@ Where should we have that dialog? I'm not sure of the best place for now let's t
 Check these first three in order:
 
 * GitHub App (install this first if onboarding a github repo): https://github.com/apps/konflux-fedora
-* Konflux UI (choose **FAS** authentication to authenticate with FAS): https://konflux.apps.kfluxfedorap01.toli.p1.openshiftapps.com/application-pipeline/
+* Konflux UI (choose **FAS** authentication to authenticate with FAS): https://konflux.fedoraproject.org/
   * After you authenticate with FAS, click **"Join the Waitlist"**. You'll be automatically approved. Just `ctrl-r` to reload the page after that.
 * Upstream user docs (for general usage): https://konflux-ci.dev/docs/
 


### PR DESCRIPTION
I'm unhappy with the way the cert is manually configured on the Route. This should be re-done with cert-manager, but it's working for now.