### PR TITLE
Update Ralph's end date for committee membership

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -23,7 +23,7 @@ members will have been elected.
 
 | Full Name       | Company | GitHub                                      | From     | Until    |
 | --------------- | ------- | ------------------------------------------- | -------- | -------- |
-| Ralph Bean      | Red Hat | [ralphbean](https://github.com/ralphbean)   | May 2024 | May 2025 |
+| Ralph Bean      | Red Hat | [ralphbean](https://github.com/ralphbean)   | May 2024 | May 2027 |
 | Andrew McNamara | Red Hat | [arewm](https://github.com/arewm)           | May 2024 | May 2026 |
 | Brian Cook      | Red Hat | [brianwcook](https://github.com/brianwcook) | May 2024 | May 2026 |
 


### PR DESCRIPTION
Per the election results, Ralph will continue his role in the governance committee for another 2 years.