### PR TITLE
Drop mention of the outreach sig meeting

### DIFF
--- a/sigs/community-outreach.md
+++ b/sigs/community-outreach.md
@@ -14,6 +14,7 @@ evaluators, and adopters. This SIG aims to accomplish this mission as follows:
 
 * Email the [Konflux mailing list](https://groups.google.com/g/konflux), optionally adding
   `[sig-community-outreach]` to the subject header.
+* Topics for the SIG should be discussed on the primary [community call](../README.md).
 
 ## Youtube
 


### PR DESCRIPTION
We decided to roll it into the general call.