### PR TITLE
Rename the ai sig to secure-ai sig

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 
 sigs/fedora* @konflux-ci/fedora-sig-admins
 sigs/community-outreach* @adambkaplan @eskultety @ralphbean
-sigs/ai* @konflux-ci/ai-sig
+sigs/ai* @konflux-ci/secure-ai-sig

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ here or reach out on the mailing list.
 
 * [Konflux + Fedora](sigs/fedora.md)
 * [Community Outreach](sigs/community-outreach.md)
-* [Artificial Intelligence](sigs/ai.md)
+* [Artificial Intelligence](sigs/secure-ai.md)

--- a/sigs/secure-ai.md
+++ b/sigs/secure-ai.md
@@ -1,4 +1,4 @@
-# Artificial Intelligence Special Interest Group
+# Secure Artificial Intelligence Special Interest Group
 
 ## Purpose
 
@@ -15,7 +15,7 @@ Topics include:
 
 * After [joining the konflux-ci slack
   workspace](https://join.slack.com/t/konflux-ci/shared_invite/zt-3g36o0a4x-Dmsy25XEGuBV79S7kd04CA),
-  join the [#ai-sig](https://konflux-ci.slack.com/archives/C09LB9WQPEF) channel.
+  join the [#secure-ai-sig](https://konflux-ci.slack.com/archives/C09LB9WQPEF) channel.
 * Email the [Konflux mailing list](https://groups.google.com/g/konflux),
-  optionally adding `[sig-ai]` to the subject header.
+  optionally adding `[secure-ai-sig]` to the subject header.
 * Topics for the SIG should be discussed on the primary [community call](../README.md).


### PR DESCRIPTION
From https://groups.google.com/g/konflux/c/DIf8BF5wqjo/m/rNP4svGwCgAJ, we should make room in the namespace for other interest groups.