### PR TITLE
Update Fedora Konflux cluster documentation

### DIFF
--- a/sigs/fedora/cluster.md
+++ b/sigs/fedora/cluster.md
@@ -1,45 +1,40 @@
 # Fedora Konflux Cluster
 
-This is a list of notes about the [Fedora Konflux cluster](https://konflux.fedoraproject.org/).
+This is a list of notes about the [Fedora Konflux cluster](https://konflux-ci.fedoraproject.org/).
 
 * **Konflux** is a new build, test, and release platform. Learn more at https://konflux-ci.dev/ and https://github.com/konflux-ci/
 * **Fedora** is your Operating System, built with love by people. Learn more at https://fedoraproject.org/
-
-For [flock 2024](https://fedoraproject.org/flock/2024/), the Konflux community provisioned a [dedicated instance of Konflux for Fedora](https://konflux.fedoraproject.org/) for community members to try, experiment, and play with. Big kudos to [@gbenhaim](https://github.com/gbenhaim) and [@manish-jangra](https://github.com/manish-jangra) for making it happen, and [@zlopez](https://github.com/zlopez) for helping with the [FAS oidc setup](https://pagure.io/fedora-infrastructure/issue/12075).
 
 This instance exists to help facilitate a dialog about what the Fedora community wants to do with respect to Konflux. Try to use it to build some stuff and see how the different konflux [resources](https://konflux-ci.dev/architecture/architecture/index.html) work. We'll keep it working and if Fedora decides to use it more, we'll seek a method to support it together with the Fedora Infra team.
 
 Where should we have that dialog? I'm not sure of the best place for now let's try [containers-sig](https://discussion.fedoraproject.org/tags/c/project/7/containers-sig). If you know a better place, let me know and we'll get this pointer updated.
 
-### Caveats
+## Important links
 
-* You can build multi-arch on arm64 and amd64. No ppc64le or s390x yet. We didn't have time to set up the IBM Cloud account before Flock.
-* The onboarding process assumes you're building containers. Some people got a proof of concept working of building an rpm, but it is still only a poc.
-* The "user access" section of the UI is broken. You have to ask an admin to grant others access to your workspace until its fixed.
+* GitHub App (install this first if onboarding a GitHub repo): https://github.com/apps/red-hat-konflux-kflux-fedora-01
+* Konflux UI (choose **FAS** authentication to authenticate with FAS): https://konflux-ci.fedoraproject.org
+* OpenShift Console: https://console-openshift-console.apps.kflux-fedora-01.84db.p1.openshiftapps.com
+* ArgoCD (used for deploying user configurations): https://argocd-tenants-config-server-argocd-tenants-config.apps.kflux-fedora-01.84db.p1.openshiftapps.com
 
-### Important links
+## Onboarding
 
-Check these first three in order:
+To onboard to Fedora's Konflux instance, submit a Merge Request to the [tenants-config](https://gitlab.com/fedora/infrastructure/konflux/tenants-config) repository which includes the manifests for creating and configuring your namespace.
 
-* GitHub App (install this first if onboarding a github repo): https://github.com/apps/konflux-fedora
-* Konflux UI (choose **FAS** authentication to authenticate with FAS): https://konflux.fedoraproject.org/
-  * After you authenticate with FAS, click **"Join the Waitlist"**. You'll be automatically approved. Just `ctrl-r` to reload the page after that.
+See the [tenants-config README](https://gitlab.com/fedora/infrastructure/konflux/tenants-config/-/blob/main/README.md) for detailed instructions on adding a new tenant.
+
+## General Resources
+
 * Upstream user docs (for general usage): https://konflux-ci.dev/docs/
+* How to test in Testing Farm from a Konflux integration test scenario: https://konflux-ci.dev/docs/how-tos/testing/integration/third-parties/testing-farm/
+* Build-time repo (builds go here as soon as they complete): https://quay.io/organization/konflux-fedora
+* Tenant gitops repo (a place where users can put their own namespaces under git control): https://gitlab.com/fedora/infrastructure/konflux/tenants-config
 
-### CLI Access
+## CLI Access
+
+* Request a token: https://oauth-openshift.apps.kflux-fedora-01.84db.p1.openshiftapps.com/oauth/token/request
 
 ```
-kubectl login --server=https://api.kfluxfedorap01.toli.p1.openshiftapps.com:6443
+kubectl login --server=https://api.kflux-fedora-01.84db.p1.openshiftapps.com:6443
 ```
 
 Using **oc** also works. See also [getting-started/cli/](https://konflux-ci.dev/docs/getting-started/cli/)
-
-### Also interesting
-
-These are also interesting
-
-* How to test in Testing Farm from a Konflux integration test scenario: https://konflux-ci.dev/docs/how-tos/testing/integration/third-parties/testing-farm/
-* OpenShift Console (for another look): https://console-openshift-console.apps.kfluxfedorap01.toli.p1.openshiftapps.com
-* Build-time repo (builds go here as soon as they complete): https://quay.io/organization/konflux-fedora
-* Admin gitops repo (deployment configuration of the instance: https://gitlab.com/fedora/infrastructure/konflux/infra-deployments
-* Tenant gitops repo (a place where users can put their own namespaces under git control): https://gitlab.com/fedora/infrastructure/konflux/tenants-config


### PR DESCRIPTION
Update cluster.md to reflect the migration to the new kflux-fedora-01 cluster. This includes updated URLs for the GitHub App, Konflux UI, OpenShift Console, ArgoCD, and CLI access with token request endpoint. Also adds onboarding instructions via the tenants-config repository.

Assisted-by: OpenCode (Claude Opus 4)