### PR TITLE
Change Andrew McNamara's term end date to May 2028

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -28,7 +28,7 @@ members will have been elected.
 | Full Name       | Company | GitHub                                      | From     | Until    |
 | --------------- | ------- | ------------------------------------------- | -------- | -------- |
 | Adam Ormandy    | Red Hat | [cit1zen](https://github.com/cit1zen)       | Nov 2025 | May 2028 |
-| Andrew McNamara | Red Hat | [arewm](https://github.com/arewm)           | May 2024 | May 2026 |
+| Andrew McNamara | Red Hat | [arewm](https://github.com/arewm)           | May 2024 | May 2028 |
 | Ralph Bean      | Red Hat | [ralphbean](https://github.com/ralphbean)   | May 2024 | May 2027 |
 
 *There is no designated facilitator at the moment. The responsibility is distributed across all the*


### PR DESCRIPTION
Updated the end date for Andrew McNamara's term based on the results of the elections held between June 15th and June 17th 2026.

The results are here: https://github.com/konflux-ci/community/issues/49